### PR TITLE
Fix broken examples/common.rs link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! - Migration: Migrate from compatible curve protocols like: GG** or CMP to DKLs23
 //!
 //! ## Examples
-//! The mod common module can be replicated  from the dkls23 github [repo](https://github.com/silence-laboratories/dkls23/examples/common.rs) under examples folder
+//! The mod common module can be replicated  from the dkls23 github [repo](https://github.com/silence-laboratories/dkls23/blob/main/examples/common.rs) under examples folder
 //! ### KeyGen
 //! ```
 //! use dkls23::keygen;


### PR DESCRIPTION
The link to the repo on the [Rustdoc page](https://dkls23.silencelaboratories.com/docs/dkls23/#examples) is broken