### PR TITLE
ci: only publish benchmark data and deploy page from main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,10 @@ jobs:
           output-file-path: /tmp/output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           benchmark-data-dir-path: docs
-          auto-push: true
+          # Only publish benchmark data from `push` to `main`. On pull_request
+          # runs the benchmark is still computed (and alerts commented), but
+          # data must not be keyed to an unmerged PR head commit.
+          auto-push: ${{ github.event_name == 'push' }}
           comment-on-alert: true
           summary-always: true
 
@@ -86,6 +89,9 @@ jobs:
     name: Create HTML page
     runs-on: github-builder
     needs: get_benchmark
+    # The page is regenerated from benchmark data committed on `main`; only
+    # deploy it from `push` events to avoid stale PR commits ending up on the page.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code (main)
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ anyhow = "1"
 derivation-path = "0.2.0"
 zeroize = "1.6.1"
 sl-mpc-mate = "1.0.0-beta"
-sl-oblivious = "1.0.0-beta"
+sl-oblivious = "=1.0.0-beta"
 
 x25519-dalek = { version = "2.0.0" }
 signature = { version = "2.2.0" }


### PR DESCRIPTION
## Problem

`dkls23.silencelaboratories.com` (GitHub Pages) showed a benchmark page pointing to `dkls23/pull/6/commits/90789ec...` — a head commit of the unmerged PR #6.

Root cause: `.github/workflows/rust.yml` runs on `pull_request` too, and the `benchmark-action` step had `auto-push: true` unconditionally. On a PR run it pushed benchmark data keyed to the PR head commit, which then surfaced on the page. Since then no benchmark ran on `main`, so the stale PR commit stayed.

## Fix

- `auto-push: ${{ github.event_name == 'push' }}` — benchmark data is only committed to `gh-pages` on `push` to `main`. On PRs the benchmark still runs and alerts are still commented, but data is not published.
- Added `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` to the `make_the_html_page` job so the page deploy only happens from `main`.

## Follow-up

After merge, trigger a benchmark run on `main` to regenerate the page with a real merged commit.